### PR TITLE
Autoload `pyim-convert-code-at-point`.

### DIFF
--- a/pyim.el
+++ b/pyim.el
@@ -3429,6 +3429,7 @@ pyim 的 translate-trigger-char 要占用一个键位，为了防止用户
     (pyim-terminate-translation)))
 
 ;; *** 将光标前的 code 字符串转换为中文
+;;;###autoload
 (defun pyim-convert-code-at-point ()
   (interactive)
   (unless (equal input-method-function 'pyim-input-method)


### PR DESCRIPTION
是这样子的，我有使用自动探针，之前每次都要 `C-\` 再按对应的 `pyim-convert-code-at-point` 的按键，
总是觉得稍微繁琐了一点，今天突然想到可以利用 autoload 机制，省去 `C-\` 这一步，操作更加流畅。

你觉得如何，有没有什么其他问题？