### PR TITLE
Use activate-input-method to activate pyim in pyim-convert-string-at-point

### DIFF
--- a/pyim.el
+++ b/pyim.el
@@ -3671,7 +3671,7 @@ PUNCT-LIST 格式类似：
   "将光标前的用户输入的字符串转换为中文."
   (interactive)
   (unless (equal input-method-function 'pyim-input-method)
-    (toggle-input-method))
+    (activate-input-method 'pyim))
   (let* ((case-fold-search nil)
          (scheme-name (pyim-scheme-name))
          (first-chars (pyim-scheme-get-option scheme-name :first-chars))


### PR DESCRIPTION
Hello,

`pyim-convert-string-at-point` command currently uses `toggle-input-method` to activate pyim, but I don't think this is a good solution. For example, if the user wants to convert some words into Chinese while he is writing Japanese using `japanese-mozc`, it will be annoying since he needs to switch the input method back and forth for every Chinese word/phrase. 

A proper solution will be to directly specify the input method to activate, i.e. `(activate-input-method 'pyim)`, so I implemented it in this PR.