### PR TITLE
show cursor and explicit "'" in pyim-page-preview-create:xingma

### DIFF
--- a/pyim.el
+++ b/pyim.el
@@ -2982,13 +2982,22 @@ minibuffer 原来显示的信息和 pyim 选词框整合在一起显示
     (or preedit "")))
 
 (defun pyim-page-preview-create:xingma (&optional separator)
-  (let* ((scheme-name (pyim-scheme-name))
-         (class (pyim-scheme-get-option scheme-name :class))
-         (prefix (pyim-scheme-get-option scheme-name :code-prefix))
-         (str (mapconcat #'identity
-                         (car pyim-imobjs)
-                         (or separator " "))))
-    str))
+  (let* ((scheme-name (pyim-scheme-name)))
+    (cl-flet* ((segment (x)
+                       (mapconcat #'identity
+                                  (car (pyim-imobjs-create x scheme-name))
+                                  (or separator " ")))
+               (fmt (x)
+                    (mapconcat #'segment
+                               (split-string x "'")
+                               "'")))
+    ;; | 显示光标位置的字符
+    (pyim-with-entered-buffer
+      (if (equal (point) (point-max))
+          (fmt (buffer-substring-no-properties (point-min) (point-max)))
+        (concat (fmt (buffer-substring-no-properties (point-min) (point)))
+                "| "
+                (fmt (buffer-substring-no-properties (point) (point-max)))))))))
 
 (defun pyim-page-menu-create (candidates position &optional separator)
   "这个函数用于创建在 page 中显示的备选词条菜单。"


### PR DESCRIPTION
When editing pyim-entered string, it's important to show the "'", which served
as a way to make short code input possible.

For example, to input "我们的祖国是花园"(wubi: trwu r pylg j awlf), you can
enter:

    trwur'pylgj'awlf

and the preview will be shown as:

    trwu r'pylg j'awlf

When you need to replace "是" with "像", move the cursor backward with `C-b`,
until:

    trwu r'pylg j|'awlf

Press `<backspace>' to delete "j", then enter "wqj":

    trwu r'pylg wqj|'awlf

Then press `<space>` to confirm the candidates, you'll get the final result:

    我们的祖国像花园