### PR TITLE
Fix for define-obsolete-function-alias breaking change in Emacs 28

### DIFF
--- a/pyim.el
+++ b/pyim.el
@@ -4035,7 +4035,7 @@ PUNCT-LIST 格式类似：
   (pyim-entered-delete-backward-imelem t))
 
 (define-obsolete-function-alias
-  'pyim-convert-code-at-point 'pyim-convert-string-at-point)
+  'pyim-convert-code-at-point 'pyim-convert-string-at-point "2.0")
 
 ;;;###autoload
 (defun pyim-convert-string-at-point (&optional return-cregexp)


### PR DESCRIPTION
I'm not very familiar with doing PRs so I hope this is correct. Also I'm not able to read Chinese that well. Sorry if I cause any inconvenience.

`define-obsolete-function-alias` signature has changed in Emacs HEAD (a.k.a Emacs 28.0.50) which breaks pyim. See [this commit](https://github.com/emacs-mirror/emacs/commit/32c6732d16385f242b1109517f25e9aefd6caa5c) in emacs for the breaking change.

Since the `WHEN` parameter is now mandatory, I've put "2.0" there since that's the version mentioned in the commit message when the call to `define-obsolete-function-alias` was written. It should be safe for Emacs <=27 too, because the `WHEN` parameter was always supported, just optional.

Hope this will help fix the same issue for other Emacs 28 and gccemacs users.