### PR TITLE
当光标在中英文字符之间时分词问题

### DIFF
--- a/pyim-cstring.el
+++ b/pyim-cstring.el
@@ -405,6 +405,63 @@ CRITERIA 字符串一般是通过 imobjs 构建的，它保留了用户原始的
                  (not (pyim-string-match-p "\\CC" string)))
         string))))
 
+(defun pyim-word-at-point (after)
+  "获取光标前的词，当 AFTER 设置为 non-nil 时，获得光标后的词 .
+默认的 (thing-at-point word) 在中英文边界处返回的始终是光标后的 word,
+本函数使得在中英文混合情况下获取光标处的词的行为更为合理"
+
+  ;; 以下例子，光标在中英文分界处
+  ;; hello|世界 调用 (pyim-word-at-point) 时返回 “hello”，
+  ;;           调用 (pyim-word-at-point t) 时返回 "世界"
+  ;; 世界|hello 调用 (pyim-word-at-point) 时返回 “世界”，
+  ;;           调用 (pyim-word-at-point t) 时返回 "hello"
+
+  (let* ((char-before (pyim-char-before-to-string 0))
+         (char-after (pyim-char-after-to-string 0)))
+    (save-excursion
+      (if (or
+           (and (not after)
+                (not (pyim-string-match-p "\\CC" char-after))
+                (not (pyim-string-match-p "\n" char-before)))
+           (and (not after)
+                (not (pyim-string-match-p "\\CC" char-before))
+                (pyim-string-match-p "\\CC" char-after))
+           )
+          (progn
+            (goto-char (- (point) 1))
+            (thing-at-point 'word t)
+            )
+        (thing-at-point 'word t))
+      )
+    )
+  )
+
+(defun pyim-bounds-of-word-at-point (after)
+  "获取光标前的词的边界坐标，当 AFTER 设置为 t 时，获得光标后的词的边界坐标.
+本函数使得在中英文混合情况下获取光标处的词的边界坐标的行为更为合理，
+可参考 pyim-word-at-point 注释中的例子
+"
+  (let* ((char-before (pyim-char-before-to-string 0))
+         (char-after (pyim-char-after-to-string 0)))
+    (save-excursion
+      (if (or
+           (and (not after)
+                (not (pyim-string-match-p "\\CC" char-after))
+                (not (pyim-string-match-p "\n" char-before)))
+           (and (not after)
+                (not (pyim-string-match-p "\\CC" char-before))
+                (pyim-string-match-p "\\CC" char-after))
+           )
+          (progn
+            (goto-char (- (point) 1))
+
+            (bounds-of-thing-at-point 'word)
+            )
+        (bounds-of-thing-at-point 'word))
+      )
+    )
+  )
+
 (defalias 'pyim-cwords-at-point 'pyim-cstring-words-at-point)
 (defun pyim-cstring-words-at-point (&optional end-of-point)
   "获取光标当前的词条列表，当 END-OF-POINT 设置为 t 时，获取光标后的词条列表。
@@ -431,9 +488,9 @@ CRITERIA 字符串一般是通过 imobjs 构建的，它保留了用户原始的
           (if end-of-point
               (string (following-char))
             (string (preceding-char))))
-         (str (thing-at-point 'word t))
+         (str (pyim-word-at-point end-of-point))
          (str-length (length str))
-         (str-boundary (bounds-of-thing-at-point 'word))
+         (str-boundary (pyim-bounds-of-word-at-point end-of-point))
          (str-beginning-pos (when str-boundary
                               (car str-boundary)))
          (str-end-pos (when str-boundary


### PR DESCRIPTION
由于 pyim-cstring-words-at-point 使用 thing-at-point 来获得当前的 word, 然后对其进行分词

但是光标在中英文之间时， thing-at-point 只返回光标右边的字符串，例如 "世界|hello"  返回的是 hello，这个时候调用 pyim-backward-word 只会往左移动一个字符。

同样对于  "hello|世界",  thing-at-point 返回的是世界, 这时调用 pyim-backward-word  也只能往左移动一个英文字符。

PR 里新增了两个函数，当光标在中英文之间时临时左移一个字符后再调用 thing-at-point 和 bounds-of-thing-at-point