### PR TITLE
增加大量中文别名

### DIFF
--- a/pyim-autoselector.el
+++ b/pyim-autoselector.el
@@ -57,6 +57,7 @@ entered (nihaom) 的第一个候选词。
 影响，需要用户自己管理。"
   :type '(choice (const nil)
                  (repeat function)))
+(defvaralias '朋友输入法-自动上屏器 'pyim-autoselector)
 
 (defun pyim-autoselector-xingma (&rest _args)
   "适用于型码输入法的自动上屏器.
@@ -84,6 +85,7 @@ entered (nihaom) 的第一个候选词。
        ((> (length entered) n)
         '(:select last))
        (t nil)))))
+(defalias '朋友输入法-自动上屏器-型码 'pyim-autoselector-xingma)
 
 
 ;; * Footer

--- a/pyim-candidates.el
+++ b/pyim-candidates.el
@@ -40,17 +40,21 @@
 (defcustom pyim-enable-shortcode t
   "启用输入联想词功能."
   :type 'boolean)
+(defvaralias '朋友输入法-是否启用联想词 'pyim-enable-shortcode)
 
 (defvar pyim-candidates nil
   "所有备选词条组成的列表.")
+(defvaralias '朋友输入法-备选词条列表 'pyim-candidates)
 
 (defvar pyim-candidates-last nil
   "上一轮备选词条列表，这个变量主要用于 autoselector 机制.")
+(defvaralias '朋友输入法-备选词-上轮 'pyim-candidates-last)
 
 (defvar pyim-candidate-position nil
   "当前选择的词条在 ‘pyim-candidates’ 中的位置.
 
 细节信息请参考 `pyim-page-refresh' 的 docstring.")
+(defvaralias '朋友输入法-备选词-位置 'pyim-candidate-position)
 
 (defvar pyim-candidates-possible-chiefs nil
   "可能做第一位候选词的词条列表。")
@@ -71,6 +75,7 @@ IMOBJS 获得候选词条。"
       (when class
         (funcall (intern (format "pyim-candidates-create:%S" class))
                  imobjs scheme-name async)))))
+(defalias '朋友输入法-备选词-创建 'pyim-candidates-create)
 
 (defun pyim-candidates-add-possible-chief (word)
   "将 WORD 添加到 `pyim-candidates-possible-chiefs'."
@@ -161,6 +166,7 @@ IMOBJS 获得候选词条。"
           (setq result (append result output))))
       (when (car result)
         (delete-dups result)))))
+(defalias '朋友输入法-备选词-创建:型码 'pyim-candidates-create:xingma)
 
 (defun pyim-candidates-create:quanpin (imobjs scheme-name &optional async)
   "`pyim-candidates-create' 处理全拼输入法的函数."
@@ -192,6 +198,7 @@ IMOBJS 获得候选词条。"
           (setq n (length (car candidates)))))
       (append (pyim-subconcat (nreverse output) "")
               candidates))))
+(defalias '朋友输入法-备选词-创建:全拼 'pyim-candidates-create:quanpin)
 
 (defun pyim-candidates-search-buffer (regexp)
   "在当前 buffer 中使用 REGEXP 搜索词条。"
@@ -212,6 +219,7 @@ IMOBJS 获得候选词条。"
       (sort words (lambda (a b)
                     (> (or (gethash a counts) 0)
                        (or (gethash b counts) 0)))))))
+(defalias '朋友输入法-备选词-搜索buffer 'pyim-candidates-search-buffer)
 
 (defun pyim-candidates-create-quanpin (imobjs scheme-name &optional fast-search)
   "`pyim-candidates-create:quanpin' 内部使用的函数。"
@@ -324,10 +332,12 @@ IMOBJS 获得候选词条。"
              ,@pinyin-chars-1
              ,@pinyin-chars-2
              )))))
+(defalias '朋友输入法-备选词-创建全拼词条 'pyim-candidates-create-quanpin)
 
 (defun pyim-candidates-create:shuangpin (imobjs _scheme-name &optional async)
   "`pyim-candidates-create' 处理双拼输入法的函数."
   (pyim-candidates-create:quanpin imobjs 'quanpin async))
+(defalias '朋友输入法-备选词-创建:双拼 'pyim-candidates-create:shuangpin)
 
 ;; * Footer
 (provide 'pyim-candidates)

--- a/pyim-codes.el
+++ b/pyim-codes.el
@@ -39,6 +39,7 @@
     (when class
       (funcall (intern (format "pyim-codes-create:%S" class))
                imobj scheme-name first-n))))
+(defalias '朋友输入法-编码-创建 'pyim-codes-create)
 
 (defun pyim-codes-create:quanpin (imobj _scheme-name &optional first-n)
   "从IMOBJ 创建一个 code 列表：codes.
@@ -63,6 +64,7 @@
            (substring py 0 (min first-n (length py)))
          py)))
    imobj))
+(defalias '朋友输入法-编码-创建:全拼 'pyim-codes-create:quanpin)
 
 (defun pyim-codes-create:shuangpin (imobj _scheme-name &optional first-n)
   (pyim-codes-create:quanpin imobj 'quanpin first-n))
@@ -77,6 +79,7 @@
                      (substring x 0 (min first-n (length x)))
                    x)))
        imobj))))
+(defalias '朋友输入法-编码-创建:型码 'pyim-codes-create:xingma)
 
 ;; * Footer
 (provide 'pyim-codes)

--- a/pyim-cregexp.el
+++ b/pyim-cregexp.el
@@ -42,6 +42,7 @@
 如果 `pyim-cregexp-build' 无法支持用户正在使用的 scheme 时，
 将使用这个 scheme."
   :type 'symbol)
+(defvaralias '朋友输入法-正则-默认方案 'pyim-cregexp-fallback-scheme)
 
 (defun pyim-cregexp-char-level-num (num)
   "根据 NUM 返回一个有效的常用汉字级别。"

--- a/pyim-dict.el
+++ b/pyim-dict.el
@@ -47,11 +47,14 @@ plist 来表示，比如：
 另外一个与这个变量功能类似的变量是： `pyim-extra-dicts', 专门
 用于和 elpa 格式的词库包集成。"
   :type 'list)
+(defvaralias '朋友输入法-词库列表 'pyim-dicts)
 
 (defvar pyim-extra-dicts nil "与 `pyim-dicts' 类似, 用于和 elpa 格式的词库包集成。.")
+(defvaralias '朋友输入法-额外词库列表 'pyim-extra-dicts)
 
 ;; ** pyim 词库管理工具
 (defvar pyim-dict-manager-buffer "*pyim-dict-manager*")
+(defvaralias '朋友输入法-词库管理器-buffer 'pyim-dict-manager-buffer)
 
 (defun pyim-dict-manager-refresh ()
   "Refresh the contents of the *pyim-dict-manager* buffer."

--- a/pyim-indicator.el
+++ b/pyim-indicator.el
@@ -40,6 +40,7 @@
 Indicator 用于显示输入法当前输入状态（英文还是中文）。"
   :type '(choice (const :tag "Off" nil)
                  (repeat :tag "Indicator functions" function)))
+(defvaralias '朋友输入法-提示器-列表 'pyim-indicator-list)
 
 (defcustom pyim-indicator-use-post-command-hook t
   "pyim-indicator daemon 是否使用 `post-command-hook' 实现。
@@ -47,12 +48,14 @@ Indicator 用于显示输入法当前输入状态（英文还是中文）。"
 如果设置为 t, 则使用 post-command-hook 实现, 设置为 nil, 则使用
 timer 实现。"
   :type 'boolean)
+(defvaralias '朋友输入法-提示器-是否使用-post-command-hook 'pyim-indicator-use-post-command-hook)
 
 (defvar pyim-indicator-cursor-color (list "orange")
   "`pyim-indicator-default' 使用的 cursor 颜色。
 
 这个变量的取值是一个list: (中文输入时的颜色 英文输入时的颜色), 如
 果英文输入时的颜色为 nil, 则使用默认 cursor 颜色。")
+(defvaralias '朋友输入法-提示器-光标颜色 'pyim-indicator-cursor-color)
 
 (defvar pyim-indicator-modeline-string (list "PYIM/C " "PYIM/E ")
   "`pyim-indicator-default' 使用的 modeline 字符串。
@@ -60,21 +63,27 @@ timer 实现。"
 这个变量的取值是一个list:
 
     (中文输入时显示的字符串 英文输入时显示的字符串)。")
+(defvaralias '朋友输入法-提示器-modeline-字符串 'pyim-indicator-modeline-string)
 
 (defvar pyim-indicator-original-cursor-color nil
   "记录 cursor 的原始颜色。")
+(defvaralias '朋友输入法-提示器-原光标颜色 'pyim-indicator-original-cursor-color)
 
 (defvar pyim-indicator-timer nil
   "`pyim-indicator-daemon' 使用的 timer.")
+(defvaralias '朋友输入法-提示器-定时器 'pyim-indicator-timer)
 
 (defvar pyim-indicator-timer-repeat 0.4)
+(defvaralias '朋友输入法-提示器-定时器重复时间 'pyim-indicator-timer-repeat)
 
 (defvar pyim-indicator-daemon-function-argument nil
   "实现 `pyim-indicator-daemon-function' 时，用于传递参数，主要原因
 是由于 `post-command-hook' 不支持参数。")
+(defvaralias '朋友输入法-提示器-后台函数参数 'pyim-indicator-daemon-function-argument)
 
 (defvar pyim-indicator-last-input-method-title nil
   "记录上一次 `current-input-method-title' 的取值。")
+(defvaralias '朋友输入法-提示器-上次输入法名称 'pyim-indicator-last-input-method-title)
 
 (defun pyim-indicator-start-daemon (func)
   "Indicator daemon, 用于实时显示输入法当前输入状态。"
@@ -89,6 +98,7 @@ timer 实现。"
             (run-with-timer
              nil pyim-indicator-timer-repeat
              #'pyim-indicator-daemon-function)))))
+(defalias '朋友输入法-提示器-启动后台 'pyim-indicator-start-daemon)
 
 (defun pyim-indicator-stop-daemon ()
   "Stop indicator daemon."
@@ -99,6 +109,7 @@ timer 实现。"
     (cancel-timer pyim-indicator-timer)
     (setq pyim-indicator-timer nil))
   (pyim-indicator-revert-cursor-color))
+(defalias '朋友输入法-提示器-停止后台 'pyim-indicator-stop-daemon)
 
 (defun pyim-indicator-daemon-function ()
   "`pyim-indicator-daemon' 内部使用的函数。"
@@ -111,11 +122,13 @@ timer 实现。"
         (dolist (indicator pyim-indicator-list)
           (when (functionp indicator)
             (funcall indicator current-input-method chinese-input-p)))))))
+(defalias '朋友输入法-提示器-后台函数 'pyim-indicator-daemon-function)
 
 (defun pyim-indicator-revert-cursor-color ()
   "将 cursor 颜色重置到 pyim 启动之前的状态。"
   (when pyim-indicator-original-cursor-color
     (set-cursor-color pyim-indicator-original-cursor-color)))
+(defalias '朋友输入法-提示器-重置光标颜色 'pyim-indicator-revert-cursor-color)
 
 (defun pyim-indicator-update-mode-line ()
   "更新 mode-line."
@@ -124,6 +137,7 @@ timer 实现。"
     (force-mode-line-update)
     (setq pyim-indicator-last-input-method-title
           current-input-method-title)))
+(defalias '朋友输入法-提示器-更新-mode-line 'pyim-indicator-update-mode-line)
 
 (defun pyim-indicator-with-cursor-color (input-method chinese-input-p)
   "Pyim 自带的 indicator, 通过光标颜色来显示输入状态。"
@@ -138,6 +152,7 @@ timer 实现。"
            (pyim-indicator-select-color
             (list "black" "white")
             pyim-indicator-original-cursor-color))))))
+(defalias '朋友输入法-提示器-自带光标颜色 'pyim-indicator-with-cursor-color)
 
 (defun pyim-indicator-select-color (colors &optional prefer-color)
   "根据背景，选择一个比较显眼的颜色。
@@ -153,6 +168,7 @@ timer 实现。"
                  (lambda (a b)
                    (> (color-distance a background)
                       (color-distance b background))))))))
+(defalias '朋友输入法-提示器-选择颜色 'pyim-indicator-select-color)
 
 (defun pyim-indicator-with-modeline (input-method chinese-input-p)
   "Pyim 自带的 indicator, 使用 mode-line 来显示输入状态。"
@@ -161,6 +177,7 @@ timer 实现。"
         (setq current-input-method-title (nth 0 pyim-indicator-modeline-string))
       (setq current-input-method-title (nth 1 pyim-indicator-modeline-string))))
   (pyim-indicator-update-mode-line))
+(defalias '朋友输入法-提示器-自带modeline 'pyim-indicator-with-modeline)
 
 (defun pyim-indicator-with-posframe (input-method chinese-input-p)
   "Pyim 自带的 indicator, 通过 posframe 来显示输入状态。"
@@ -175,6 +192,7 @@ timer 实现。"
                            :poshandler #'posframe-poshandler-point-top-left-corner
                            :background-color (pyim-indicator-select-color (list "red" "green" "blue" "orange")))
           (posframe-hide buffer))))))
+(defalias '朋友输入法-提示器-自带posframe 'pyim-indicator-with-posframe)
 
 ;; * Footer
 (provide 'pyim-indicator)

--- a/pyim-preview.el
+++ b/pyim-preview.el
@@ -40,6 +40,7 @@
 
 (defvar pyim-preview-overlay nil
   "用于保存光标处预览字符串的 overlay.")
+(defvaralias '朋友输入法-预览-overlay 'pyim-preview-overlay)
 
 (pyim-register-local-variables '(pyim-preview-overlay))
 
@@ -56,6 +57,7 @@
       (setq pyim-preview-overlay (make-overlay pos pos))
       (if input-method-highlight-flag
           (overlay-put pyim-preview-overlay 'face 'pyim-preview-face)))))
+(defalias '朋友输入法-预览-设置overlay 'pyim-preview-setup-overlay)
 
 (defun pyim-preview-delete-overlay ()
   "删除 pyim 光标处实时预览功能所需要的 overlay.
@@ -64,6 +66,7 @@
 `pyim-preview-overlay' 中保存的 overlay。"
   (if (and (overlayp pyim-preview-overlay) (overlay-start pyim-preview-overlay))
       (delete-overlay pyim-preview-overlay)))
+(defalias '朋友输入法-预览-删除overlay 'pyim-preview-delete-overlay)
 
 (defun pyim-preview-refresh ()
   "刷新光标处预览.
@@ -94,16 +97,19 @@ pyim 会使用 Emacs overlay 机制在 *待输入buffer* 光标处高亮显示�
     ;; Highlight new preview string.
     (move-overlay pyim-preview-overlay
                   (overlay-start pyim-preview-overlay) (point))))
+(defalias '朋友输入法-预览-刷新 'pyim-preview-refresh)
 
 (defun pyim-preview-delete-string ()
   "删除已经插入 buffer 的 preview 预览字符串。"
   (when (overlay-start pyim-preview-overlay)
     (delete-region (overlay-start pyim-preview-overlay)
                    (overlay-end pyim-preview-overlay))))
+(defalias '朋友输入法-预览-删除字符串 'pyim-preview-delete-string)
 
 (defun pyim-preview-start-point ()
   "Preview 字符串的开始位置。"
   (overlay-start pyim-preview-overlay))
+(defalias '朋友输入法-预览-开始位置 'pyim-preview-start-point)
 
 ;; * Footer
 (provide 'pyim-preview)

--- a/pyim-probe.el
+++ b/pyim-probe.el
@@ -69,6 +69,7 @@
        (or (car (setq ppss (nthcdr 3 ppss)))
            (car (setq ppss (cdr ppss)))
            (nth 3 ppss))))))
+(defalias '朋友输入法-探针-程序模式 'pyim-probe-program-mode)
 
 (defvar org-heading-regexp)
 (defvar org-use-speed-commands)
@@ -132,6 +133,7 @@
                  (> (length (pyim-entered-get 'point-before)) 0)))
       (not (or (pyim-string-match-p "\\cc" non-digit-str-before-1)
                (> (length (pyim-entered-get 'point-before)) 0))))))
+(defalias '朋友输入法-探针-动态英语 'pyim-probe-dynamic-english)
 
 (defun pyim-probe-auto-english ()
   "激活这个 pyim 探针函数后，使用下面的规则自动切换中英文输入：
@@ -150,6 +152,7 @@
                 (pyim-string-match-p "\\cc" str-before-2)
               (and (not (pyim-string-match-p "\\cc" str-before-1))
                    (= (length (pyim-entered-get 'point-before)) 0)))))))
+(defalias '朋友输入法-探针-自动英语 'pyim-probe-dynamic-english)
 
 (declare-function evil-normal-state-p "evil")
 (defun pyim-probe-evil-normal-mode ()
@@ -168,6 +171,7 @@
     (and (member (char-to-string char)
                  (mapcar #'car pyim-punctuation-dict))
          (string-match "^[ \t]*$" line-string))))
+(defalias '朋友输入法-探针-行首半角 'pyim-probe-punctuation-line-beginning)
 
 (declare-function pyim-entered-get "pyim-entered" (&optional type))
 (declare-function org-inside-LaTeX-fragment-p "org")
@@ -181,6 +185,7 @@
         (puncts (mapcar #'car pyim-punctuation-dict)))
     (and (member str-before-1 puncts)
          (member (char-to-string char) puncts))))
+(defalias '朋友输入法-探针-半角后半角 'pyim-probe-punctuation-after-punctuation)
 
 (defun pyim-probe-org-latex-mode ()
   "org-mode 中的 latex fragment 和 latex 宏指令中自动切换到英文输入."

--- a/pyim-pymap.el
+++ b/pyim-pymap.el
@@ -43,15 +43,19 @@
 
 (defvar pyim-pymap-py2cchar-cache1 nil
   "拼音查汉字功能需要的变量.")
+(defvaralias '朋友输入法-拼音映射表-拼音转汉字-缓存1 'pyim-pymap-py2cchar-cache1)
 
 (defvar pyim-pymap-py2cchar-cache2 nil
   "拼音查汉字功能需要的变量.")
+(defvaralias '朋友输入法-拼音映射表-拼音转汉字-缓存2 'pyim-pymap-py2cchar-cache1)
 
 (defvar pyim-pymap-py2cchar-cache3 nil
   "拼音查汉字功能需要的变量.")
+(defvaralias '朋友输入法-拼音映射表-拼音转汉字-缓存3 'pyim-pymap-py2cchar-cache1)
 
 (defvar pyim-pymap-cchar2py-cache nil
   "汉字转拼音功能需要的变量.")
+(defvaralias '朋友输入法-拼音映射表-汉字转拼音-缓存 'pyim-pymap-py2cchar-cache1)
 
 (defvar pyim-pymap
   '(("a" "阿啊呵腌|嗄吖锕||錒")
@@ -471,6 +475,7 @@
     http://www.gov.cn/zwgk/2013-08/19/content_2469793.htm
 
 但不是完全一致。")
+(defvaralias '朋友输入法-拼音映射表 'pyim-pymap)
 
 (defvar pyim-pymap-commonly-used-cchar
   (cl-remove-if-not
@@ -732,12 +737,14 @@
 蠋翾儳儴𩾌鳚鳛麑麖彟嬿鬒蘘欂甗𨟠巇酅髎犨𨭉㸌爔瀱瀼襫孅骦耰𤫉瓖鬘
 趯罍鼱鳠鳡鳣爟爚灈韂糵礵鹴皭龢鳤亹籥𫚭玃醾齇觿" ""))
   "常用汉字")
+(defvaralias '朋友输入法-拼音映射表-常用汉字表 'pyim-pymap-commonly-used-cchar)
 
 ;; ** "汉字 -> 拼音" 以及 "拼音 -> 汉字" 的转换函数
 (defun pyim-pymap-cache-create (&optional force)
   "创建 pymap 相关的 cache."
   (pyim-pymap-cchar2py-cache-create force)
   (pyim-pymap-py2cchar-cache-create force))
+(defalias '朋友输入法-拼音映射表-创建缓存 'pyim-pymap-cache-create)
 
 (defun pyim-pymap-py2cchar-cache-create (&optional force)
   "构建 pinyin 到 chinese char 的缓存.
@@ -770,6 +777,7 @@
                  (orig-value (gethash key pyim-pymap-py2cchar-cache3)))
             (puthash key (delete-dups `(,@orig-value ,@cchars))
                      pyim-pymap-py2cchar-cache3)))))))
+(defalias '朋友输入法-拼音映射表-拼音转汉字-创建缓存 'pyim-pymap-py2cchar-cache-create)
 
 (defun pyim-pymap-py2cchar-get (pinyin &optional equal-match return-list include-seperator)
   "获取拼音与 PINYIN 想匹配的所有汉字.
@@ -797,6 +805,7 @@
       (if include-seperator
           output
         (remove "|" output)))))
+(defalias '朋友输入法-拼音映射表-拼音转汉字-获取汉字 'pyim-pymap-cchar2py-get)
 
 (defun pyim-pymap-cchar2py-get (char-or-str)
   "获取字符或者字符串 CHAR-OR-STR 对应的拼音 code.
@@ -815,6 +824,7 @@ pyim 在特定的时候需要读取一个汉字的拼音，这个工作由此完
                char-or-str)))
     (when (= (length key) 1)
       (gethash key pyim-pymap-cchar2py-cache))))
+(defalias '朋友输入法-拼音映射表-汉字转拼音-获取拼音)
 
 (defun pyim-pymap-cchar2py-cache-create (&optional force)
   "Build pinyin cchar->pinyin hashtable from `pyim-pymap'.
@@ -832,11 +842,13 @@ If FORCE is non-nil, FORCE build."
             (if cache
                 (puthash key (append (list py) cache) pyim-pymap-cchar2py-cache)
               (puthash key (list py) pyim-pymap-cchar2py-cache))))))))
+(defalias '朋友输入法-拼音映射表-汉字转拼音-缓存-创建 'pyim-pymap-cchar2py-cache-create)
 
 (defun pyim-pymap-cchar< (a b)
   "如果汉字 A 的使用频率大于汉字 B 的使用频率时，返回 non-nil"
   (< (or (cl-position a pyim-pymap-commonly-used-cchar :test #'equal) 1000000)
      (or (cl-position b pyim-pymap-commonly-used-cchar :test #'equal) 1000000)))
+(defalias '朋友输入法-拼音映射表-汉字比较< 'pyim-pymap-cchar<)
 
 (defun pyim-pymap-sort-pymap ()
   "对 `pyim-pymap' 重新排序, 这个函数主要用于维护 `pyim-pymap'."
@@ -848,6 +860,7 @@ If FORCE is non-nil, FORCE build."
                          #'pyim-pymap-cchar<)))
             pymap))
     (reverse pymap)))
+(defalias '朋友输入法-拼音映射表-排序拼音映射表 'pyim-pymap-sort-pymap)
 
 (defun pyim-pymap-build-pymap ()
   "使用 libpinyin 自带的 data 文件创建 `pyim-pymap'.
@@ -912,6 +925,7 @@ If FORCE is non-nil, FORCE build."
        (emacs-lisp-mode)
        (indent-region (point-min) (point-max))
        (buffer-string)))))
+(defalias '朋友输入法-拼音映射表-创建拼音映射表 'pyim-pymap-build-pymap)
 
 ;; * Footer
 (provide 'pyim-pymap)

--- a/pyim-scheme.el
+++ b/pyim-scheme.el
@@ -37,6 +37,7 @@
 (defcustom pyim-default-scheme 'quanpin
   "设置 pyim 使用哪一种输入法方案，默认使用全拼输入."
   :type 'symbol)
+(defvaralias '朋友输入法-默认方案 'pyim-default-scheme)
 
 (defcustom pyim-assistant-scheme 'quanpin
   "设置辅助输入法方案.
@@ -44,14 +45,17 @@
 这个功能主要用于五笔等形码输入法，在忘记编码的情况下，
 临时激活某种辅助输入法（比如：拼音输入法）来输入汉字。"
   :type 'symbol)
+(defvaralias '朋友输入法-辅助方案 'pyim-assistant-scheme)
 
 (defvar pyim-assistant-scheme-enable nil
   "设置临时 scheme, 用于五笔等形码输入法临时拼音输入。")
+(defvaralias '朋友输入法-是否启用辅助方案 'pyim-assistant-scheme-enable)
 
 (pyim-register-local-variables '(pyim-assistant-scheme-enable))
 
 (defvar pyim-schemes nil
   "Pyim 支持的所有拼音方案.")
+(defvaralias '朋友输入法-方案列表 'pyim-schemes)
 
 ;;;###autoload
 (defun pyim-default-scheme (&optional scheme-name)
@@ -67,6 +71,7 @@
           scheme-name)
       (message "PYIM: %s 不是一个有效的 scheme 名称, 继续使用 %s." scheme-name pyim-default-scheme)
       nil)))
+(defalias '朋友输入法-设置默认方案 'pyim-default-scheme)
 
 (defun pyim-scheme-add (scheme)
   "Add SCHEME to `pyim-schemes'"
@@ -78,11 +83,13 @@
                         pyim-schemes)))
         (push scheme pyim-schemes))
     (message "PYIM: Invalid pyim scheme config!")))
+(defalias '朋友输入法-方案-添加 'pyim-scheme-add)
 
 (defun pyim-scheme-get (scheme-name)
   "获取名称为 SCHEME-NAME 的输入法方案。"
   (when scheme-name
     (assoc scheme-name pyim-schemes)))
+(defalias '朋友输入法-方案-获取 'pyim-scheme-get)
 
 (defun pyim-scheme-name (&optional default)
   "获取输入法 scheme"
@@ -96,6 +103,7 @@
     (if (assq scheme-name pyim-schemes)
         scheme-name
       'quanpin)))
+(defalias '朋友输入法-方案-获取名字 'pyim-scheme-name)
 
 (defun pyim-scheme-get-option (scheme-name option)
   "获取名称为 SCHEME-NAME 的输入法方案，并提取其属性 OPTION 。"
@@ -107,6 +115,7 @@
       (if (member option (cdr scheme))
           (plist-get (cdr scheme) option)
         (pyim-scheme-get-option scheme-inherit option)))))
+(defalias '朋友输入法-方案-获取属性 'pyim-scheme-get-option)
 
 (pyim-scheme-add
  '(quanpin

--- a/pyim.el
+++ b/pyim.el
@@ -48,6 +48,7 @@
 (defcustom pyim-select-finish-hook nil
   "Pyim 选词完成时运行的 hook."
   :type 'hook)
+(defvaralias '朋友输入法-选词完成时的钩子 'pyim-select-finish-hook)
 
 (defcustom pyim-convert-string-at-point-hook nil
   "Hook of `pyim-convert-string-at-point'.
@@ -59,6 +60,7 @@
 Tip: 用户也可以利用 `pyim-outcome-trigger-function-default' 函数
 来构建适合自己的 hook 函数。"
   :type 'hook)
+(defvaralias '朋友输入法-转换光标处字符串成中文时的钩子 'pyim-convert-string-at-point-hook)
 
 (defcustom pyim-select-word-by-number t
   "使用数字键来选择词条.
@@ -66,13 +68,18 @@ Tip: 用户也可以利用 `pyim-outcome-trigger-function-default' 函数
 如果设置为 nil, 将直接输入数字，适用于使用数字做为
 编码的输入法。"
   :type 'boolean)
+(defvaralias '朋友输入法-是否用数字选词 'pyim-select-word-by-number)
 
 ;;;###autoload
 (defvar pyim-title "PYIM ")
+(defvaralias '朋友输入法-名称 'pyim-title)
 
 (defvar pyim-load-hook nil)
+(defvaralias '朋友输入法-加载时的钩子 'pyim-load-hook)
 (defvar pyim-activate-hook nil)
+(defvaralias '朋友输入法-激活时的钩子 'pyim-activate-hook)
 (defvar pyim-deactivate-hook nil)
+(defvaralias '朋友输入法-退出时的钩子 'pyim-deactivate-hook)
 
 (defvar pyim-mode-map
   (let ((map (make-sparse-keymap))
@@ -127,6 +134,7 @@ Tip: 用户也可以利用 `pyim-outcome-trigger-function-default' 函数
     (define-key map "\C-g" #'pyim-quit-clear)
     map)
   "Pyim 的 Keymap.")
+(defvaralias '朋友输入法-模式键位映射 'pyim-mode-map)
 
 ;; ** pyim 输入法定义
 (defun pyim-input-method (key)
@@ -151,6 +159,7 @@ Tip: 用户也可以利用 `pyim-outcome-trigger-function-default' 函数
                   (list (aref input-string 0))
                 (mapcar #'identity input-string))))
         (pyim-process-terminate)))))
+(defalias '朋友输入法-输入 'pyim-input-method)
 
 (defun pyim-input-method-1 (key)
   "`pyim-input-method-1' 是 `pyim-input-method' 内部使用的函数。
@@ -216,6 +225,7 @@ Tip: 用户也可以利用 `pyim-outcome-trigger-function-default' 函数
     ;; Since KEY doesn't start any translation, just return it.
     ;; But translate KEY if necessary.
     (char-to-string key)))
+(defalias '朋友输入法-输入-1 'pyim-input-method-1)
 
 ;; ** Pyim 输入法注册
 ;;;###autoload
@@ -267,10 +277,12 @@ pyim 使用函数 `pyim-activate' 启动输入法的时候，会将变量
   (run-hooks 'pyim-activate-hook)
   (setq-local input-method-function #'pyim-input-method)
   nil)
+(defalias '朋友输入法-激活 'pyim-activate)
 
 (defun pyim-kill-emacs-hook-function ()
   "Pyim function which is used in `kill-emacs-hook'."
   (pyim-process-save-dcaches t))
+(defalias '朋友输入法-kill-emacs-hook-函数 'pyim-kill-emacs-hook-function)
 
 ;; ** 取消激活功能
 (defun pyim-deactivate ()
@@ -280,6 +292,7 @@ pyim 使用函数 `pyim-activate' 启动输入法的时候，会将变量
   (kill-local-variable 'input-method-function)
   (pyim-process-stop-daemon)
   (run-hooks 'pyim-deactivate-hook))
+(defalias '朋友输入法-取消 'pyim-deactivate)
 
 ;; ** pyim 从 minibuffer 退出功能
 (defun pyim-exit-from-minibuffer ()
@@ -287,6 +300,7 @@ pyim 使用函数 `pyim-activate' 启动输入法的时候，会将变量
   (deactivate-input-method)
   (when (<= (minibuffer-depth) 1)
     (remove-hook 'minibuffer-exit-hook 'pyim-exit-from-minibuffer)))
+(defalias '朋友输入法-从minibuffer退出 'pyim-exit-from-minibuffer)
 
 ;; ** pyim 重启功能
 (defun pyim-restart ()
@@ -298,6 +312,7 @@ pyim 使用函数 `pyim-activate' 启动输入法的时候，会将变量
   (let ((save-personal-dcache
          (yes-or-no-p "重启 pyim 前，需要保存个人词频信息吗？ ")))
     (pyim-restart-1 save-personal-dcache)))
+(defalias '朋友输入法-重启 'pyim-restart)
 
 (defun pyim-restart-1 (&optional save-personal-dcache _refresh-common-dcache)
   "重启 pyim，用于编程环境.
@@ -307,6 +322,7 @@ pyim 使用函数 `pyim-activate' 启动输入法的时候，会将变量
 REFRESH-COMMON-DCACHE 已经废弃，不要再使用了。"
   (pyim-process-save-dcaches save-personal-dcache)
   (pyim-process-init-dcaches :force))
+(defalias '朋友输入法-重启-1 'pyim-restart-1)
 
 ;; ** 键盘输入处理功能
 (defun pyim-self-insert-command ()
@@ -326,6 +342,7 @@ REFRESH-COMMON-DCACHE 已经废弃，不要再使用了。"
    (t
     (pyim-process-outcome-handle 'last-char)
     (pyim-process-terminate))))
+(defalias '朋友输入法-自插入指令 'pyim-self-insert-command)
 
 (cl-pushnew 'pyim-self-insert-command pyim-process-self-insert-commands)
 
@@ -339,21 +356,25 @@ SILENT 设置为 t 是，不显示提醒信息。"
       (setq output (pyim-process-create-word string))
       (unless silent
         (message "将词条: %S 加入 personal 缓冲。" output)))))
+(defalias '朋友输入法-加入光标处词语到个人词库 'pyim-create-word-at-point)
 
 (defun pyim-create-2cchar-word-at-point ()
   "将光标前2个中文字符组成的字符串加入个人词库。"
   (interactive)
   (pyim-create-word-at-point 2))
+(defalias '朋友输入法-将光标前2个中文字符组成的字符串加入个人词库 'pyim-create-2cchar-word-at-point)
 
 (defun pyim-create-3cchar-word-at-point ()
   "将光标前3个中文字符组成的字符串加入个人词库。"
   (interactive)
   (pyim-create-word-at-point 3))
+(defalias '朋友输入法-将光标前3个中文字符组成的字符串加入个人词库 'pyim-create-3cchar-word-at-point)
 
 (defun pyim-create-4cchar-word-at-point ()
   "将光标前4个中文字符组成的字符串加入个人词库。"
   (interactive)
   (pyim-create-word-at-point 4))
+(defalias '朋友输入法-将光标前4个中文字符组成的字符串加入个人词库 'pyim-create-4cchar-word-at-point)
 
 (defun pyim-create-word-from-selection ()
   "Add the selected text as a Chinese word into the personal dictionary."
@@ -367,6 +388,7 @@ SILENT 设置为 t 是，不显示提醒信息。"
             (error "不是纯中文字符串")
           (setq output (pyim-process-create-word string))
           (message "将词条: %S 插入 personal file。" output))))))
+(defalias '朋友输入法-加入选区词语到个人词库 'pyim-create-word-from-selection)
 
 ;; ** 导入词条功能
 (defun pyim-import-words-and-counts (file &optional merge-method silent)
@@ -424,6 +446,7 @@ MERGE-METHOD 是一个函数，这个函数需要两个数字参数，代表词�
     (pyim-process-update-personal-words)
 
     (message "PYIM: 词条和词频信息导入完成！")))
+(defalias '朋友输入法-导入词条及相应词频 'pyim-import-words-and-counts)
 
 ;; ** 导出功能
 (defalias 'pyim-export-words-and-counts 'pyim-dcache-export-words-and-counts)
@@ -451,6 +474,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
           (pyim-process-delete-word word)))
       (forward-line 1)))
   (message "pyim: 批量删词完成！"))
+(defalias '朋友输入法-删除文件中的词语 'pyim-delete-words-in-file)
 
 (defun pyim-delete-last-word ()
   "从个人词库中删除最新创建的词条。"
@@ -458,6 +482,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
   (when pyim-process-last-created-words
     (pyim-process-delete-word (car pyim-process-last-created-words))
     (message "pyim: 从个人词库中删除词条 “%s” !" (car pyim-process-last-created-words))))
+(defalias '朋友输入法-从个人词库中删除最新创建的词条 'pyim-delete-last-word)
 
 (defun pyim-delete-word-at-point (&optional number silent)
   "将光标前字符数为 NUMBER 的中文字符串从个人词库中删除
@@ -467,6 +492,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
       (pyim-process-delete-word string)
       (unless silent
         (message "词条: \"%s\" 已经从个人词库缓冲中删除。" string)))))
+(defalias '朋友输入法-从个人词库删除光标处词语 'pyim-delete-word-at-point)
 
 (defun pyim-delete-word ()
   "从个人词库中删除词条。"
@@ -488,6 +514,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
           (setq pyim-process-last-created-words
                 (remove word pyim-process-last-created-words))
           (message "将词条: %S 从 personal 缓冲中删除。" word))))))
+(defalias '朋友输入法-将高亮选择的词条从个人词库中删除 'pyim-delete-word)
 
 ;; ** 选词功能
 (defun pyim-select-word-simple ()
@@ -502,12 +529,13 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
       (pyim-process-outcome-handle 'last-char)
     (pyim-process-outcome-handle 'candidate))
   (pyim-process-terminate))
+(defalias '朋友输入法-从选词框中选择当前词条 'pyim-select-word-simple)
 
 (defun pyim-select-word ()
   "从选词框中选择当前词条，然后删除该词条对应拼音。"
   (interactive)
   (pyim-process-create-code-criteria)
-  (if (null (pyim-process-get-candidates))  ; 如果没有选项，输入空格
+  (if (null (pyim-process-get-candidates)) ; 如果没有选项，输入空格
       (progn
         (pyim-process-outcome-handle 'last-char)
         (pyim-process-terminate))
@@ -516,6 +544,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
       (if (and class (functionp func))
           (funcall func)
         (call-interactively #'pyim-select-word:pinyin)))))
+(defalias '朋友输入法-从选词框中选择当前词条并删除对应输入码 'pyim-select-word)
 
 (defun pyim-select-word:pinyin ()
   "从选词框中选择当前词条，然后删除该词条对应拼音。"
@@ -575,6 +604,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
       (pyim-process-terminate)
       ;; pyim 使用这个 hook 来处理联想词。
       (run-hooks 'pyim-select-finish-hook))))
+(defalias '朋友输入法-选择当前词条并删除对应拼音 'pyim-select-word:pinyin)
 
 (defun pyim-select-word:xingma ()
   "从选词框中选择当前词条，然后删除该词条对应编码。"
@@ -594,6 +624,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
     (pyim-process-terminate)
     ;; pyim 使用这个 hook 来处理联想词。
     (run-hooks 'pyim-select-finish-hook)))
+(defalias '朋友输入法-选择当前词条并删除对应型码 'pyim-select-word:xingma)
 
 (defun pyim-select-word-by-number (&optional n)
   "使用数字编号来选择对应的词条。"
@@ -616,12 +647,14 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
     ;; 有些输入法使用数字键编码，这种情况下，数字键就
     ;; 不能用来选词了。
     (call-interactively #'pyim-self-insert-command)))
+(defalias '朋友输入法-使用数字编号来选择对应的词条 'pyim-select-word)
 
 (defun pyim-select-subword-by-number (&optional n)
   "以词定字功能。"
   (interactive)
   (pyim-process-toggle-set-subword-info (or n 1))
   (pyim-process-run t))
+(defalias '朋友输入法-使用数字编号以词定字 'pyim-select-subword-by-number)
 
 ;; ** 翻页和翻词功能
 (defalias 'pyim-previous-page #'pyim-page-previous-page)
@@ -635,6 +668,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
   (interactive)
   (pyim-process-outcome-handle "")
   (pyim-process-terminate))
+(defalias '朋友输入法-取消输入 'pyim-quit-clear)
 
 ;; ** 字母上屏功能
 (defun pyim-quit-no-clear ()
@@ -642,6 +676,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
   (interactive)
   (pyim-process-outcome-handle 'pyim-entered)
   (pyim-process-terminate))
+(defalias '朋友输入法-字母上屏 'pyim-quit-no-clear)
 
 ;; ** 中英文输入模式切换
 (defun pyim-toggle-input-ascii ()
@@ -649,6 +684,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
   (interactive)
   (setq pyim-process-input-ascii
         (not pyim-process-input-ascii)))
+(defalias '朋友输入法-切换中英文输入模式 'pyim-toggle-input-ascii)
 
 ;; ** 主辅输入法切换功能
 (defun pyim-toggle-assistant-scheme ()
@@ -664,6 +700,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
     (setq pyim-assistant-scheme-enable
           (not pyim-assistant-scheme-enable))
     (pyim-process-run)))
+(defalias '朋友输入法-切换辅助输入方案 'pyim-toggle-assistant-scheme)
 
 ;; ** PYIM 输入操作命令
 (defun pyim-forward-point ()
@@ -673,6 +710,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
     (ignore-errors
       (forward-char)))
   (pyim-process-run t))
+(defalias '朋友输入法-前移光标 'pyim-forward-point)
 
 (defun pyim-backward-point ()
   "光标后移"
@@ -681,6 +719,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
     (ignore-errors
       (backward-char)))
   (pyim-process-run t))
+(defalias '朋友输入法-后移光标 'pyim-backward-point)
 
 (defun pyim-backward-imelem (&optional search-forward)
   "光标向后移动一个 imelem 对应的字符串
@@ -691,11 +730,13 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
     (pyim-process-with-entered-buffer
       (goto-char position))
     (pyim-process-run t)))
+(defalias '朋友输入法-后移一个imelem 'pyim-backward-imelem)
 
 (defun pyim-forward-imelem ()
   "光标向前移动一个 imelem 对应的字符串"
   (interactive)
   (pyim-backward-imelem t))
+(defalias '朋友输入法-前移一个imelem 'pyim-forward-imelem)
 
 (defun pyim-end-of-line ()
   "光标移至行尾"
@@ -703,6 +744,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
   (pyim-process-with-entered-buffer
     (end-of-line))
   (pyim-process-run t))
+(defalias '朋友输入法-移动光标到行尾 'pyim-end-of-line)
 
 (defun pyim-beginning-of-line ()
   "光标移至行首"
@@ -710,6 +752,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
   (pyim-process-with-entered-buffer
     (beginning-of-line))
   (pyim-process-run t))
+(defalias '朋友输入法-移动光标到行首 'pyim-beginning-of-line)
 
 (defun pyim-delete-backward-char (&optional n)
   "向后删除1个字符"
@@ -721,11 +764,13 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
       (pyim-process-run t)
     (pyim-process-outcome-handle "")
     (pyim-process-terminate)))
+(defalias '朋友输入法-向后删除一个字符 'pyim-delete-backward-char)
 
 (defun pyim-delete-forward-char ()
   "向前删除1个字符"
   (interactive)
   (pyim-delete-backward-char -1))
+(defalias '朋友输入法-向前删除一个字符 'pyim-delete-forward-char)
 
 (defun pyim-delete-backward-imelem (&optional search-forward)
   "向后删除一个 imelem 对应的字符串"
@@ -734,11 +779,13 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
     (pyim-process-with-entered-buffer
       (delete-region (point) position))
     (pyim-process-run t)))
+(defalias '朋友输入法-向后删除一个imelem 'pyim-delete-backward-imelem)
 
 (defun pyim-delete-forward-imelem ()
   "向前删除一个 imelem 对应的字符串"
   (interactive)
   (pyim-delete-backward-imelem t))
+(defalias '朋友输入法-向前删除一个imelem 'pyim-delete-forward-imelem)
 
 ;; ** 金手指功能
 ;;;###autoload
@@ -818,6 +865,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
        ((pyim-string-match-p "[[:punct:]：－]" (pyim-char-before-to-string 0))
         (call-interactively 'pyim-punctuation-translate-at-point))
        (t (message "Pyim: pyim-convert-string-at-point did nothing."))))))
+(defalias '朋友输入法-转化光标处字符串为中文 'pyim-convert-string-at-point)
 
 ;; ** 编码反查功能
 (defun pyim-search-word-code ()
@@ -833,6 +881,7 @@ FILE 的格式与 `pyim-dcache-export' 生成的文件格式相同，
             (message "PYIM (%S): %S -> %S" pyim-default-scheme string codes)
           (message "PYIM: 没有找到 %S 对应的编码。" string)))
       (deactivate-mark))))
+(defalias '朋友输入法-反查编码 'pyim-search-word-code)
 
 ;; ** pyim 中文字符串工具
 (require 'pyim-cstring)


### PR DESCRIPTION
最近有感于业务代码中大量低质量的英文命名增加了对业务概念的理解负担，想尝试一下中文编程的概念是否有利于改变做这个状况，想做一些小实验。而中文变量是现有的技术条件下支持的最好的，pyim 帮助我很简单地克服了在中文中间输入半角符号的问题。

国内的 emacs 普及度不高，需要大量与外国程序员交流，其实不适合作中文编程的实验，但是中文输入法却是一个特别的例外，像楼主的注释里也大量地使用了中文，这一块基本是有中文读写能力的人才对这相关代码有使用需求，有改进动力。一时兴起给 pyim 大量的变量和函数名增加了中文别名。

然而要真正使用起这些中文变量名就要大量地改变旧有的代码了，我也不是 pyim 的主要贡献者，所以只能说是起了些花哨些的命名，可以在自己配置中写得易懂些。不知道进一步的实验楼主有没有意愿继续尝试。

anyway, 不管用不用得上，算是一点有意思的尝试吧，推给楼主。

加 alias 发现 pyim 代码量比想象中的大很多，感谢楼主不懈地改进 pyim.