### PR TITLE
fix error: (invalid-function pyim-process-with-entered-buffer)

### DIFF
--- a/pyim-page.el
+++ b/pyim-page.el
@@ -36,7 +36,9 @@
 (require 'pyim-preview)
 
 (eval-when-compile
-  (require 'pyim-entered))
+  (require 'pyim-entered)
+  ;; pyim-page rely on macro: pyim-process-with-entered-buffer
+  (require 'pyim-process))
 
 (defgroup pyim-page nil
   "Page tools for pyim."

--- a/pyim-process.el
+++ b/pyim-process.el
@@ -34,7 +34,9 @@
 (require 'pyim-entered)
 (require 'pyim-imobjs)
 (require 'pyim-codes)
-(require 'pyim-page)
+;; avoid cyclic dependency
+;; pyim-page rely on macro: pyim-process-with-entered-buffer
+;;(require 'pyim-page)
 (require 'pyim-candidates)
 (require 'pyim-preview)
 (require 'pyim-indicator)


### PR DESCRIPTION
this error only come to picture when code is compiled, due to compilater can
not find macro defintion