### PR TITLE
use elint and byte-compile for CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@
 /tests/pyim-tests-temp-*
 /tests/deps/
 
+TAGS
+tags

--- a/pyim-candidates.el
+++ b/pyim-candidates.el
@@ -32,6 +32,8 @@
 (require 'pyim-dcache)
 (require 'pyim-codes)
 (require 'pyim-pymap)
+(require 'pyim-cregexp)
+(require 'pyim-cstring)
 
 (defgroup pyim-candidates nil
   "Candidates of pyim."

--- a/pyim-common.el
+++ b/pyim-common.el
@@ -30,6 +30,8 @@
 
 ;;; Code:
 ;; * 代码                                                                 :code:
+(require 'cl-lib)
+(require 'subr-x)
 
 (defgroup pyim-common nil
   "pyim common."

--- a/pyim-cregexp.el
+++ b/pyim-cregexp.el
@@ -28,9 +28,13 @@
 ;;; Code:
 ;; * 代码                                                           :code:
 (require 'cl-lib)
-(require 'pyim-pymap)
+(require 'isearch)
 (require 'xr)
 (require 'rx)
+(require 'pyim-pymap)
+(require 'pyim-scheme)
+(require 'pyim-imobjs)
+(require 'pyim-dcache)
 
 (defgroup pyim-cregexp nil
   "Chinese regexp tools for pyim."

--- a/pyim-dcache.el
+++ b/pyim-dcache.el
@@ -29,6 +29,7 @@
 ;; * 代码                                                           :code:
 (require 'cl-lib)
 (require 'pyim-common)
+(require 'pyim-pymap)
 (require 'url-util)
 
 (defgroup pyim-dcache nil

--- a/pyim-imobjs.el
+++ b/pyim-imobjs.el
@@ -30,6 +30,7 @@
 (require 'cl-lib)
 (require 'pyim-common)
 (require 'pyim-pinyin)
+(require 'pyim-scheme)
 
 (defgroup pyim-imobjs nil
   "Imobjs lib for pyim."

--- a/pyim-outcome.el
+++ b/pyim-outcome.el
@@ -29,6 +29,7 @@
 ;; * 代码                                                           :code:
 (require 'cl-lib)
 (require 'pyim-common)
+(require 'pyim-scheme)
 
 (defgroup pyim-outcome nil
   "Outcome tools for pyim."

--- a/pyim-preview.el
+++ b/pyim-preview.el
@@ -30,6 +30,7 @@
 (require 'cl-lib)
 (require 'pyim-common)
 (require 'pyim-process)
+(require 'mule)
 
 (defgroup pyim-preview nil
   "Preview libs for pyim."
@@ -40,6 +41,8 @@
 
 (defvar pyim-preview-overlay nil
   "用于保存光标处预览字符串的 overlay.")
+
+(defvar input-method-highlight-flag) ;; fixed compiling error
 
 (pyim-register-local-variables '(pyim-preview-overlay))
 

--- a/pyim.el
+++ b/pyim.el
@@ -223,7 +223,7 @@ Tip: 用户也可以利用 `pyim-outcome-trigger-function-default' 函数
 
 ;; ** Pyim 输入法注册
 ;;;###autoload
-(register-input-method "pyim" "UTF-8" #'pyim-activate pyim-title)
+(register-input-method "pyim" "UTF-8" #'pyim-activate pyim-title "")
 
 ;; ** PYim 输入法启动功能
 ;;;###autoload

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -2,10 +2,11 @@
 SHELL = /bin/sh
 EMACS ?= emacs
 
-clean:
-	@rm -rf pyim-tests-temp-*
+.PHONY: test lint clean deps compile
 
-.PHONY: deps
+clean:
+	@rm -rf "pyim-tests-temp-*" "../*.elc" "*.elc"
+
 deps:
 	@mkdir -p deps;
 	@if [ ! -f deps/xr.el ]; then curl -L "https://git.savannah.gnu.org/cgit/emacs/elpa.git/plain/xr.el?h=externals/xr" > deps/xr.el; fi;
@@ -14,8 +15,17 @@ deps:
     ## Download pyim-basedict V0.5.0 (commit: 7495c974ada99f9fed96d8e85d8b97dabce9532c)
 	@if [ ! -f deps/pyim-basedict.pyim ]; then curl -L "https://git.savannah.gnu.org/cgit/emacs/elpa.git/plain/pyim-basedict.pyim?h=externals/pyim-basedict&id=7495c974ada99f9fed96d8e85d8b97dabce9532c" > deps/pyim-basedict.pyim; fi;
 	@if [ ! -f deps/pyim-basedict.el ]; then curl -L "https://git.savannah.gnu.org/cgit/emacs/elpa.git/plain/pyim-basedict.el?h=externals/pyim-basedict&id=7495c974ada99f9fed96d8e85d8b97dabce9532c" > deps/pyim-basedict.el; fi;
+	@if [ ! -f deps/posframe.el ]; then curl -L "https://raw.githubusercontent.com/tumashu/posframe/master/posframe.el" > deps/posframe.el; fi;
+	@if [ ! -f deps/liberime.el ]; then curl -L "https://raw.githubusercontent.com/merrickluo/liberime/master/liberime.el" > deps/liberime.el; fi;
 
-.PHONY: test
-test: deps clean
+
+lint: deps
+	@$(EMACS) --batch --quick --directory .. --directory ./deps --load ./pyim-elint.el 2>&1 | grep -vE "pyim-cregexp.el:[0-9]+:Warning: Empty varlist in let|pyim-indicator.el:[0-9]+:Error: Call to undefined function: posframe-show" | grep -E "([Ee]rror|[Ww]arning):" && exit 1 || exit 0
+
+compile: deps clean
+	@$(EMACS) --batch --quick --directory .. --directory ./deps --load ./pyim-byte-compile.el 2>&1 | grep -E "([Ee]rror|[Ww]arning):" && exit 1 || exit 0
+
+# test: lint compile deps clean
+test: deps clean compile
 	@$(EMACS) --batch --quick --directory .. --directory ./deps --load ./pyim-tests.el
-	@rm -rf pyim-tests-temp-*
+	@rm -rf "pyim-tests-temp-*"

--- a/tests/pyim-byte-compile.el
+++ b/tests/pyim-byte-compile.el
@@ -1,0 +1,49 @@
+;;; pyim-elint.el --- syntax check the code  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2022 Free Software Foundation, Inc.
+;;
+;; Author: Chen Bin <chenbin.sh@gmail.com>
+;; URL: https://github.com/tumashu/pyim
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;  Syntax check the pyim code.  It's used in Emacs cli.
+;;
+
+;;; Code:
+
+(require 'find-lisp)
+
+(let ((files (find-lisp-find-files-internal
+              "../"
+              (lambda (file dir)
+                (and (not (file-directory-p (expand-file-name file dir)))
+                     (string-match "\\.el$" file)
+                     (not (string-match "\\.dir-locals.el" file))))
+              (lambda (dir parent)
+                (not (or (string= dir ".")
+                         (string= dir "..")
+                         (string= dir ".git")
+                         (string= dir ".svn")
+                         (string= dir ".deps")
+                         (string= dir "tests")
+                         (file-symlink-p (expand-file-name dir parent))))))))
+  (dolist (file files)
+    (byte-compile-file file)))
+
+(provide 'pyim-byte-compile)
+;;; pyim-elint.el ends here

--- a/tests/pyim-elint.el
+++ b/tests/pyim-elint.el
@@ -1,0 +1,34 @@
+;;; pyim-elint.el --- syntax check the code  -*- lexical-binding: t -*-
+
+;; Copyright (C) 2022 Free Software Foundation, Inc.
+;;
+;; Author: Chen Bin <chenbin.sh@gmail.com>
+;; URL: https://github.com/tumashu/pyim
+
+;; This file is NOT part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful,
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+;; GNU General Public License for more details.
+
+;; You should have received a copy of the GNU General Public License
+;; along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+;;; Commentary:
+;;  Syntax check the pyim code.  It's used in Emacs cli.
+;;
+
+;;; Code:
+(require 'elint)
+
+(let ((elint-directory-skip-re "\\(\\.dir-locals\\|ldefs-boot\\|loaddefs\\)\\.el\\'"))
+  (elint-directory ".."))
+
+(provide 'pyim-elint)
+;;; pyim-elint.el ends here


### PR DESCRIPTION
- github CI后自动编译所有`*.el`，如有警告或错误CI会报错
- 已修复所有编译错误，主要是少了`require`,在emacs26/27/28下测试过

提供了`make lint -C tests/`和`make compile -C tests`两个命令，前者使用`elint`（好像很多语法不能识别，不是很可靠，没有用在CI中），后者使用`byte-compile`，已整合于CI中。
