### PR TITLE
only test emacs major versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        emacs_version: [25.1, 25.2, 25.3, 26.1, 26.2, 26.3, 27.1, 27.2, 28.1, snapshot]
+        emacs_version: [25.1, 26.1, 27.1, 28.1, snapshot]
     steps:
     - uses: purcell/setup-emacs@master
       with:


### PR DESCRIPTION
emacs的api比较稳定,测试一个大的版本就可以了. 否则CI会无缘无故的失败. 另外也可以节省一点提高CI服务的同志们的带宽.
