### PR TITLE
run specific version of emacs to test latest pyim code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ EMACS ?= emacs
 
 .PHONY: test lint clean deps compile
 
-EMACS_BATCH_OPTS=--batch --quick --directory . --directory .deps
+EMACS_GENERIC_OPTS=--quick --directory . --directory .deps
+EMACS_BATCH_OPTS:=--batch $(EMACS_GENERIC_OPTS)
 RM=@rm -rf
 
 XR_URL="https://git.savannah.gnu.org/cgit/emacs/elpa.git/plain/xr.el?h=externals/xr"
@@ -41,3 +42,6 @@ compile: deps
 test: compile deps
 	@$(EMACS) $(EMACS_BATCH_OPTS) --load ./tests/pyim-tests.el
 	$(RM) pyim-tests-temp-*
+
+runemacs: deps
+	@$(EMACS) $(EMACS_GENERIC_OPTS) --load ./tests/pyim-emacs-init.el

--- a/README.org
+++ b/README.org
@@ -406,6 +406,19 @@ pyim 当前内置两种指示器实现方式：
 
 * 开发
 请参考 [[file:Development.org][Development.org]] 文档
+
+
+* 试用
+在pyim项目根目录运行命令=make runemacs=试用最新的pyim。
+
+只有pyim和其依赖的包被载入。用户自己的emacs配置不会被载入。
+
+指定运行的Emacs版本用以下命令,
+#+begin_src sh
+EMACS=~/my-whatever-directory/bin/emacs make runemacs
+#+end_src
+
+Emacs启动后运行=M-x toggle-input-method= 或按=C-/=启动输入法。
 * 捐赠
 您可以通过小额捐赠的方式支持 pyim 的开发工作，具体方式：
 

--- a/tests/pyim-emacs-init.el
+++ b/tests/pyim-emacs-init.el
@@ -1,0 +1,10 @@
+(require 'pyim)
+(setq default-input-method "pyim")
+
+(defun pyim-test-find-file (file)
+  "Read FILE's content into current buffer."
+  (let* ((files (directory-files-recursively default-directory file)))
+    (file-truename (car files))))
+
+(setq pyim-dicts (list (list :name "basedict" :file (pyim-test-find-file "pyim-basedict.pyim"))))
+(message "pyim-dicts=%s" pyim-dicts)


### PR DESCRIPTION
增加了`make runemacs`命令，可以启动指定版本的emacs测试pyim的当前代码。

![image](https://user-images.githubusercontent.com/184553/175234511-0adf0ea0-d0d1-4449-820e-350c6458dc3e.png)
