### PR TITLE
Add ziranma (自然码) scheme.

### DIFF
--- a/pyim-scheme.el
+++ b/pyim-scheme.el
@@ -409,6 +409,63 @@
     ("oo" "o")
     ("ou" "ou"))))
 
+(pyim-scheme-add
+ '(ziranma
+   :document "自然码双拼（不含形码）方案"
+   :class shuangpin
+   :first-chars "abcdefghijklmnopqrstuvwxyz"
+   :rest-chars  "abcdefghijklmnopqrstuvwxyz"
+   :prefer-triggers nil
+   :cregexp-support-p t
+   :keymaps
+   (("a" "a" "a")
+    ("b" "b" "ou")
+    ("c" "c" "iao")
+    ("d" "d" "uang" "iang")
+    ("e" "e" "e")
+    ("f" "f" "en")
+    ("g" "g" "eng")
+    ("h" "h" "ang")
+    ("i" "ch" "i")
+    ("j" "j" "an")
+    ("k" "k" "ao")
+    ("l" "l" "ai")
+    ("m" "m" "ian")
+    ("n" "n" "in")
+    ("o" "o" "uo" "o")
+    ("p" "p" "un")
+    ("q" "q" "iu")
+    ("r" "r" "uan")
+    ("s" "s" "iong" "ong")
+    ("t" "t" "ue" "ve")
+    ("u" "sh" "u")
+    ("v" "zh" "v" "ui")
+    ("w" "w" "ia" "ua")
+    ("x" "x" "ie")
+    ("y" "y" "ing" "uai")
+    ("z" "z" "ei")
+    ("aa" "a")
+    ("an" "an")
+    ("aj" "an")
+    ("ai" "ai")
+    ("al" "ai")
+    ("ao" "ao")
+    ("ak" "ao")
+    ("ah" "ang")
+    ("ee" "e")
+    ("ei" "ei")
+    ("ez" "ei")
+    ("en" "en")
+    ("ef" "en")
+    ("er" "er")
+    ("eg" "eng")
+    ("oo" "o")
+    ("ou" "ou")
+    ("ob" "ou")
+    )
+   )
+ )
+
 ;; * Footer
 (provide 'pyim-scheme)
 


### PR DESCRIPTION
自然码是一款双拼输入法（https://zh.wikipedia.org/wiki/自然码），与微软双拼类似，但在完整的实现中（比如 https://github.com/mutoe/rime）包含形码，也就是所谓的“以音码为主、形码为辅的双拼加形类编码方案”。

添加这个 schema 之后，除了可以在 pyim 中使用自然码输入法，也可以在 isearch 和 ivy 之类的补全框架中用自然码音码匹配中文：`:cregexp-support-p t`