### PR TITLE
Fix defcustom type definitions

### DIFF
--- a/pyim-cregexp.el
+++ b/pyim-cregexp.el
@@ -44,7 +44,7 @@
 
 如果 `pyim-cregexp-build' 无法支持用户正在使用的 scheme 时，
 将使用这个 scheme."
-  :type 'symbol)
+  :type 'pyim-scheme)
 
 (defun pyim-cregexp-build (string &optional char-level-num chinese-only)
   "根据 STRING 构建一个中文 regexp.

--- a/pyim-dcache.el
+++ b/pyim-dcache.el
@@ -57,7 +57,8 @@
 100M 时，速度还可以，可以尝试，需要注意的是，这个后端只支持全拼和
 双拼输入法，不支持型码输入法，如果使用这个后端，用户需要自己在
 Emacs 配置中添加 (require \\='pyim-dregcache)."
-  :type 'symbol)
+  :type '(radio (const pyim-dhashcache)
+                (const pyim-dregcache)))
 
 (defvar pyim-dcache-auto-update t
   "是否自动创建和更新词库对应的 dcache 文件.

--- a/pyim-dict.el
+++ b/pyim-dict.el
@@ -46,7 +46,9 @@ plist 来表示，比如：
 
 另外一个与这个变量功能类似的变量是： `pyim-extra-dicts', 专门
 用于和 elpa 格式的词库包集成。"
-  :type 'list)
+  :type '(repeat (plist :key-type (choice (const :tag "词库名称" :name)
+                                          (const :tag "词库文件" :file))
+                        :value-type string)))
 
 (defvar pyim-extra-dicts nil
   "类似 `pyim-dicts', 不过这个变量主要用于 elpa 词库包。

--- a/pyim-indicator.el
+++ b/pyim-indicator.el
@@ -35,16 +35,16 @@
   "Indicator for pyim."
   :group 'pyim)
 
-(defcustom pyim-indicator-list (list #'pyim-indicator-with-cursor-color #'pyim-indicator-with-modeline)
+(defcustom pyim-indicator-list '(pyim-indicator-with-cursor-color
+                                 pyim-indicator-with-modeline)
   "PYIM 当前使用的 indicators.
 Indicator 用于显示输入法当前输入状态（英文还是中文）。"
-  :type '(choice (const :tag "Off" nil)
-                 (repeat :tag "Indicator functions" function)))
+  :type '(repeat :tag "Indicator functions" function))
 
 (defcustom pyim-indicator-use-post-command-hook t
   "pyim-indicator daemon 是否使用 `post-command-hook' 实现。
 
-如果设置为 t, 则使用 post-command-hook 实现, 设置为 nil, 则使用
+如果设置为 t, 则使用 `post-command-hook' 实现, 设置为 nil, 则使用
 timer 实现。"
   :type 'boolean)
 

--- a/pyim-outcome.el
+++ b/pyim-outcome.el
@@ -40,7 +40,8 @@
 (defcustom pyim-outcome-magic-converter nil
   "将 “待选词条” 在 “上屏” 之前自动转换为其他字符串.
 这个功能可以实现“简转繁”，“输入中文得到英文”之类的功能。"
-  :type 'function)
+  :type '(choice (const nil)
+                 function))
 
 (defcustom pyim-outcome-trigger "v"
   "用于触发特殊操作的字符，相当与单字快捷键.
@@ -91,7 +92,7 @@ pyim 使用函数 `pyim-process-select-handle-char' 来处理特殊功能触发�
 具体请参考 `pyim-outcome--get-trigger' 。"
   :type '(choice (const nil) string))
 
-(defcustom pyim-outcome-trigger-function 'pyim-outcome-trigger-function-default
+(defcustom pyim-outcome-trigger-function #'pyim-outcome-trigger-function-default
   "可以使用 `pyim-outcome-trigger' 激活的函数。
 
 这个函数与『单字快捷键配合使用』，当光标前面的字符为汉字字符时，

--- a/pyim-page.el
+++ b/pyim-page.el
@@ -42,13 +42,24 @@
 细节信息请参考 `pyim-page--refresh' 的 docstring."
   :type 'number)
 
+(define-widget 'pyim-page-tooltip-1 'lazy nil
+  :type '(choice (const posframe)
+                 (const popup)
+                 (const popon)
+                 (const minibuffer)))
+
+(define-widget 'pyim-page-tooltip 'lazy
+  "如何绘制 pyim 选词框，详见变量 `pyim-page-tooltip'。"
+  :type '(choice (pyim-page-tooltip-1 :tag "单一选词框")
+                 (repeat :tag "依次选择可用选词框" pyim-page-tooltip-1)))
+
 (defcustom pyim-page-tooltip '(posframe popup minibuffer)
   "如何绘制 pyim 选词框.
 
 1. 当这个变量取值为 posframe 时，使用 posframe 包来绘制选词框，
-   使用 emacs 26 图形版的用户推荐使用这个选项。
+   使用 Emacs 26 图形版的用户推荐使用这个选项。
 2. 当这个变量取值为 popup 时，使用 popup-el 包来绘制选词框，
-   这个选项可以在 emacs 图形版和终端版使用，速度没有 posframe 快，
+   这个选项可以在 Emacs 图形版和终端版使用，速度没有 posframe 快，
    偶尔会遇到选词框错位的问题。
 3. 当这个变量取值为 popon 时，使用 popon 包来绘制选词框，这个选项
    效果类似 popup。
@@ -56,14 +67,13 @@
    这个选项也作为其他选项不可用时的 fallback.
 5. 当这个变量的取值是为一个 list 时，pyim 将按照优先顺序动态
    选择一个当前环境可用的 tooltip."
-  :type '(choice (repeat (choice (const posframe)
-                                 (const popup)
-                                 (const popon)
-                                 (const minibuffer)))
-                 (const posframe)
-                 (const popup)
-                 (const popon)
-                 (const minibuffer)))
+  :type 'pyim-page-tooltip)
+
+(define-widget 'pyim-page-style 'lazy "选词框的格式"
+  :type '(choice (const :tag "单行选词框" two-lines)
+                 (const :tag "双行选词框" one-line)
+                 (const :tag "垂直选词框" vertical)
+                 (const :tag "单行选词框 (minibuffer)" minibuffer)))
 
 (defcustom pyim-page-style 'two-lines
   "这个变量用来控制选词框的格式.
@@ -74,10 +84,7 @@ pyim 内建的有四种选词框格式：
 2. two-lines   双行选词框
 3. vertical    垂直选词框
 4. minibuffer  单行选词框 (minibuffer 中专用)"
-  :type '(choice (const two-lines)
-                 (const one-line)
-                 (const vertical)
-                 (const minibuffer)))
+  :type 'pyim-page-style)
 
 (defcustom pyim-page-tooltip-style-alist
   '((minibuffer . minibuffer))
@@ -85,8 +92,8 @@ pyim 内建的有四种选词框格式：
 
 这个表是一个 alist, 每个元素的 car 代表 tooltip, cdr 代表对应的
 page style."
-  :type '(alist :key-type symbol
-                :value-type symbol))
+  :type '(alist :key-type pyim-page-tooltip-1
+                :value-type pyim-page-style))
 
 (defcustom pyim-page-posframe-border-width 0
   "posframe的内间距。

--- a/pyim-pinyin.el
+++ b/pyim-pinyin.el
@@ -39,9 +39,10 @@
     ("in" "ing")
     ("un" "ong"))
   "设定模糊音."
-  :type 'sexp)
+  :type '(alist :key-type string
+                :value-type (list string)))
 
-(defvar pyim-pinyin--shenmu
+(defvar pyim-pinyin--shengmu
   '("b" "p" "m" "f" "d" "t" "n" "l" "g" "k" "h"
     "j" "q" "x" "z" "c" "s" "zh" "ch" "sh" "r" "y" "w"))
 
@@ -119,7 +120,7 @@
                       ;; 截取后剩余的字符串 rest 找不出声母
                       (equal (car (pyim-pinyin--get-shenmu rest)) "")
                       ;; 截取后的韵母最后一个字符是一个有效声母
-                      (member (substring yunmu -1) pyim-pinyin--shenmu)
+                      (member (substring yunmu -1) pyim-pinyin--shengmu)
                       ;; 截取得到的韵母如果去掉最后一个字符，还是有效的韵母
                       (member (substring yunmu 0 -1) pyim-pinyin--yunmu))
                  (if (not (pyim-pinyin--valid-charpy-p shenmu (substring yunmu 0 -1)))
@@ -140,7 +141,7 @@
         shenmu)
     (while (> i 0)
       (setq shenmu (substring pinyin 0 i))
-      (if (member shenmu pyim-pinyin--shenmu)
+      (if (member shenmu pyim-pinyin--shengmu)
           (setq i 0)
         (setq i (1- i))
         (setq shenmu "")))

--- a/pyim-process.el
+++ b/pyim-process.el
@@ -48,7 +48,7 @@
 
 这个变量的取值为一个函数列表，这个函数列表中的任意一个函数的
 运行结果为 t 时，pyim 开启英文输入功能。"
-  :type 'symbol)
+  :type '(repeat function))
 
 (defcustom pyim-force-input-chinese-functions nil
   "让 pyim 强制输入中文.
@@ -56,11 +56,11 @@
 这个变量的取值为一个函数列表，这个函数列表中的任意一个函数的运行
 结果为 t 时，pyim 将强制输入中文功能,无视
 `pyim-english-input-switch-functions' 的设置."
-  :type 'symbol)
+  :type '(repeat function))
 
 (defvaralias 'pyim-autoselector 'pyim-process-autoselector)
 (defcustom pyim-process-autoselector nil
-  "已经启用的自动上屏器.
+  "当前启用的自动上屏器列表.
 
 自动上屏器是一个函数。假设用户已经输入 \"nihao\", 并按下 \"m\" 键，
 那么当前entered 就是 \"nihaom\". 上次 entered 是 \"nihao\". 那么
@@ -78,12 +78,11 @@ entered (nihaom) 的第一个候选词。
 
 注意：多个 autoselector 函数运行时，最好不要相互影响，如果相互有
 影响，需要用户自己管理。"
-  :type '(choice (const nil)
-                 (repeat function)))
+  :type '(repeat function))
 
 (defcustom pyim-process-run-delay 0.5
   "延迟多少秒开始延迟获取词条。"
-  :type 'integer)
+  :type 'number)
 
 (defcustom pyim-select-finish-hook nil
   "Pyim 选词完成时运行的 hook."

--- a/pyim-punctuation.el
+++ b/pyim-punctuation.el
@@ -67,7 +67,12 @@
     ("|" "÷")
     ("{" "『"))
   "标点符号表."
-  :type 'list)
+  :type
+  '(repeat (cons (string :tag "半角标点")
+                 (choice :tag "全角标点"
+                         (list :tag "单个" string)
+                         (list :tag "成对" (string :tag "前")
+                               (string :tag "后"))))))
 
 (defcustom pyim-punctuation-half-width-functions nil
   "让 pyim 输入半角标点.
@@ -75,8 +80,7 @@
 取值为一个函数列表，这个函数列表中的任意一个函数的运行结果为 t 时，
 pyim 输入半角标点，函数列表中每个函数都有一个参数：char ，表示
 最后输入的一个字符，具体见: `pyim-process-select-handle-char' 。"
-  :type '(choice (const nil)
-                 (repeat function)))
+  :type '(repeat function))
 
 (defvar pyim-punctuation-translate-p '(auto yes no)
   "这个变量的第一个元素的取值用于控制标点符号全角半角模式切换.

--- a/pyim-scheme.el
+++ b/pyim-scheme.el
@@ -34,16 +34,23 @@
   "Scheme tools for pyim."
   :group 'pyim)
 
+(define-widget 'pyim-scheme 'lazy "输入法方案"
+  :type '(choice (const :tag "全拼" quanpin)
+                 (const :tag "双拼" shuangpin)
+                 (const :tag "形码" xingma)
+                 (const :tag "五笔" wubi)
+                 (symbol :tag "其他")))
+
 (defcustom pyim-default-scheme 'quanpin
   "设置 pyim 使用哪一种输入法方案，默认使用全拼输入."
-  :type 'symbol)
+  :type 'pyim-scheme)
 
 (defcustom pyim-assistant-scheme 'quanpin
   "设置辅助输入法方案.
 
 这个功能主要用于五笔等形码输入法，在忘记编码的情况下，
 临时激活某种辅助输入法（比如：拼音输入法）来输入汉字。"
-  :type 'symbol)
+  :type 'pyim-scheme)
 
 (defvar pyim-scheme--enable-assistant-p nil
   "设置临时 scheme, 用于五笔等形码输入法临时拼音输入。")


### PR DESCRIPTION
So that certain `setopt` [1] actions do not issue warnings.  In addition, fixed minor issues around defcustom when I see them, like their docstrings and initial values.

[1] `setopt` is available since Emacs 29.

* pyim-scheme.el {widget} pyim-scheme: added a type alias of a "scheme" for later reuse pyim-default-scheme: switch to use more concrete type 'pyim-scheme

* pyim-cregexp.el pyim-cregexp-fallback-scheme: use type 'pyim-scheme.

* pyim-dcache.el pyim-dcache-backend: use radio to choose between the two available options.

* pyim-dict.el pyim-dicts: use a more concrete type definition with tags.

* pyim-indicator.el pyim-indicator-list: reformatted default value; removed overlapping type nil from (repeat function), becuase `(repeat ...)` allows empty lists. pyim-indicator-use-post-command-hook: quote `post-command-hook` in docstring.

* pyim-outcome.el pyim-outcome-magic-converter: added nil type, because it can be nil. pyim-outcome-trigger-function: prefer function quote in its init value.

* pyim-page.el:
{widget} pyim-page-tooltip-1: added a type alias for a single tooltip.
{widget} pyim-page-tooltip: added a type alias for "one or more" tooltips.
{widget} pyim-page-style: added a type alias for a page style.
pyim-page-tooltip: "Emacs" shoule be upper case; use type alias as its type.
pyim-page-tooltip-style-alist: use type aliases to narrow down type def.

* pyim-pinyin.el pyim-pinyin-fuzzy-alist: narrow down possible type def. pyim-pinyin--shengmu: renamed from `pyim-pinyin--shenmu`.

* pyim-process.el pyim-english-input-switch-functions: type should be a list of functions. pyim-force-input-chinese-functions: type should be a list of functions. pyim-process-autoselector: changed docstring to specify it is a "list"; removed overlapping type nil.
pyim-process-run-delay: type should be number because of the initial value.

* pyim-punctuation.el pyim-punctuation-dict: reworked type def for better customize view. pyim-punctuation-half-width-functions: removed overlapping type nil.